### PR TITLE
Tidy and remove unused variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 var PSC          = require('packet-stream-codec')
-var u            = require('./util')
 var initStream   = require('./stream')
 var createRemoteApi    = require('./remote-api')
 var createLocalApi = require('./local-api')
@@ -20,7 +19,7 @@ function createMuxrpc (remoteManifest, localManifest, localApi, id, perms, codec
 
   //pass the manifest to the permissions so that it can know
   //what something should be.
-  var _cb, ws
+  var _cb
   var context = {
       _emit: function (event, value) {
         emitter && emitter._emit(event, value)

--- a/permissions.js
+++ b/permissions.js
@@ -7,10 +7,6 @@ function isFunction (f) {
   return 'function' === typeof f
 }
 
-function join (str) {
-  return Array.isArray(str) ? str.join('.') : str
-}
-
 function toArray(str) {
   return isArray(str) ? str : str.split('.')
 }
@@ -82,7 +78,7 @@ module.exports = function (opts) {
 
   if(opts) perms(opts)
 
-  perms.pre = function (name, args) {
+  perms.pre = function (name) {
     name = isArray(name) ? name : [name]
     if(allow && !u.prefix(allow, name))
       return new Error('method:'+name + ' is not in list of allowed methods')
@@ -91,13 +87,13 @@ module.exports = function (opts) {
       return new Error('method:'+name + ' is on list of disallowed methods')
   }
 
-  perms.post = function (err, value) {
+  perms.post = function () {
     //TODO
   }
 
   //alias for pre, used in tests.
-  perms.test = function (name, args) {
-    return perms.pre(name, args)
+  perms.test = function (name) {
+    return perms.pre(name)
   }
 
   perms.get = function () {

--- a/pull-weird.js
+++ b/pull-weird.js
@@ -57,8 +57,7 @@ module.exports = function (weird, _done) {
       }, function (err) {
         if(weird && !weird.writeEnd) weird.write(null, err || true)
         done && done(err)
-      })
-      (read)
+      })(read)
     }
   }
 }

--- a/test/abort.js
+++ b/test/abort.js
@@ -6,18 +6,6 @@ var Abortable = require('pull-abortable')
 
 function id (e) { return e }
 
-function abortStream(onAbort, onAborted) {
-  return function (read) {
-    return function (abort, cb) {
-      if(abort && onAbort) onAbort(abort)
-      read(abort, function (end, data) {
-        if(end && onAborted) onAborted(end)
-        cb(end, data)
-      })
-    }
-  }
-}
-
 module.exports = function (serializer) {
   tape('stream abort', function (t) {
     t.plan(2)
@@ -28,7 +16,7 @@ module.exports = function (serializer) {
 
     var A = mux(client, null, serializer) ()
     var B = mux(null, client, serializer) ({
-      drainAbort: function (n) {
+      drainAbort: function () {
         return pull(
           pull.take(3),
           pull.through(console.log),
@@ -48,7 +36,7 @@ module.exports = function (serializer) {
     var sent = []
 
     pull(
-      pull.values([1,2,3,4,5,6,7,8,9,10], function (abort) {
+      pull.values([1,2,3,4,5,6,7,8,9,10], function () {
         t.ok(sent.length < 10, 'sent is correct')
         t.end()
       }),

--- a/test/async.js
+++ b/test/async.js
@@ -208,7 +208,7 @@ module.exports = function(serializer, buffers) {
 
     var s = A.createStream()
 
-    A.hello('world', function (err, value) {
+    A.hello('world', function (err) {
       t.ok(err)
       t.end()
     })
@@ -221,7 +221,7 @@ module.exports = function(serializer, buffers) {
 
     var s = A.createStream()
 
-    A.hello('world', function (err, value) {
+    A.hello('world', function (err) {
       console.log('CB!')
       t.ok(err)
       t.end()
@@ -391,7 +391,7 @@ module.exports = function(serializer, buffers) {
 
     var A = mux(client, null, serializer)()
     var B = mux(null, client, serializer)({
-      things: function (len) {
+      things: function () {
         return function (read) {
           read(err, function () {})
         }

--- a/test/attack.js
+++ b/test/attack.js
@@ -47,7 +47,7 @@ tape('request which is not public', function (t) {
   //create a client with a different manifest to the server.
   //create a server that 
 
-  A = createClient(t)
+  const A = createClient(t)
 
   A.get('foo', function (err, val) {
     t.ok(err)
@@ -64,7 +64,7 @@ tape('sink which is not public', function (t) {
 
   pull(
     pull.values(["ACCESS", "GRANTED"]),
-    A.write(null, function (err, ary) {
+    A.write(null, function (err) {
       t.ok(err)
       t.end()
     })

--- a/test/auth-perms.js
+++ b/test/auth-perms.js
@@ -1,6 +1,5 @@
 var tape = require('tape')
 var pull = require('pull-stream')
-var pushable = require('pull-pushable')
 var mux = require('../')
 var cont = require('cont')
 var Permissions = require('../permissions')
@@ -31,7 +30,6 @@ var store = {
 }
 
 function createServerAPI (store) {
-  var rpc
   var name = 'nobody'
 
   //this wraps a session.
@@ -97,7 +95,7 @@ function createServerAPI (store) {
 
   session.nested = session
 
-  return rpc = mux(null, api, id)(session, perms)
+  return mux(null, api, id)(session, perms)
 }
 
 function createClientAPI() {
@@ -135,7 +133,7 @@ tape('secure rpc', function (t) {
         t.ok(err); cb()
       }))
     }
-  ])(function (err) {
+  ])(function () {
     client.login({name: 'user', pass: 'password'}, function (err, res) {
       if(err) throw err
       t.ok(res.okay)
@@ -170,7 +168,7 @@ tape('secure rpc', function (t) {
             ]); cb()
           }))
         }
-      ])(function (err) {
+      ])(function () {
           t.end()
         })
     })
@@ -250,8 +248,8 @@ tape('nested sessions', function (t) {
         t.ok(err); cb()
       }))
     }
-  ])(function (err) {
-    client.login({name: 'nested', pass: 'foofoo'}, function (err, res) {
+  ])(function () {
+    client.login({name: 'nested', pass: 'foofoo'}, function () {
       cont.para([
         function (cb) {
           client.nested.get('foo', function (err, value) {
@@ -280,7 +278,7 @@ tape('nested sessions', function (t) {
             ]); cb()
           }))
         }
-      ])(function (err) {
+      ])(function () {
           
           t.end()
         })

--- a/test/closed.js
+++ b/test/closed.js
@@ -32,7 +32,7 @@ module.exports = function(serializer) {
 
       A.close(function (err) {
         if (err) throw err
-        A.hello('world', function (err, value) {
+        A.hello('world', function (err) {
           console.log(err)
           t.ok(err)
           t.end()
@@ -63,7 +63,7 @@ module.exports = function(serializer) {
 
       A.close(function (err) {
         if (err) throw err
-        pull(A.stuff(5), pull.collect(function (err, ary) {
+        pull(A.stuff(5), pull.collect(function (err) {
           t.ok(err)
           console.log(err)
           t.end()
@@ -77,7 +77,7 @@ module.exports = function(serializer) {
 
     var A = mux(client, null, serializer) ()
     var B = mux(null, client, serializer) ({
-      things: function (someParam) {
+      things: function () {
         throw "should not be called"
       }
     })
@@ -145,12 +145,12 @@ module.exports = function(serializer) {
       pull.drain(function (data) {
         drained.push(data)
         t.notOk(closed)
-      }, function (err) {
+      }, function () {
         next()
       })
     )
 
-    B.close(function (closed) {
+    B.close(function () {
       closed = true
       next()
     })
@@ -215,7 +215,7 @@ module.exports = function(serializer) {
       //this should have already gotten through,
       //but should not have closed yet.
       t.deepEqual(drained, [1])
-      B.close(true, function (closed) {
+      B.close(true, function () {
         closed = true
         next()
       })

--- a/test/initial-perms-bootstrap.js
+++ b/test/initial-perms-bootstrap.js
@@ -1,6 +1,5 @@
 var tape = require('tape')
 var pull = require('pull-stream')
-var pushable = require('pull-pushable')
 var mux = require('../')
 var cont = require('cont')
 
@@ -29,7 +28,6 @@ var store = {
 }
 
 function createServerAPI (store) {
-  var rpc
   var name = 'nobody'
 
   //this wraps a session.
@@ -59,10 +57,8 @@ function createServerAPI (store) {
 
   session.nested = session
 
-  return rpc = mux(null, api, id)(session, {allow: ['manifest', 'get']})
+  return mux(null, api, id)(session, {allow: ['manifest', 'get']})
 }
-
-function noop () {}
 
 function createClientAPI(cb) {
   return mux(cb, null, id)()
@@ -92,7 +88,7 @@ tape('secure rpc', function (t) {
           t.ok(err); cb()
         }))
       }
-    ])(function (err) {
+    ])(function () {
       t.end()
     })
   }

--- a/test/initial-perms.js
+++ b/test/initial-perms.js
@@ -1,6 +1,5 @@
 var tape = require('tape')
 var pull = require('pull-stream')
-var pushable = require('pull-pushable')
 var mux = require('../')
 var cont = require('cont')
 
@@ -28,7 +27,6 @@ var store = {
 }
 
 function createServerAPI (store) {
-  var rpc
   var name = 'nobody'
 
   //this wraps a session.
@@ -55,7 +53,7 @@ function createServerAPI (store) {
 
   session.nested = session
 
-  return rpc = mux(null, api, id)(session, {allow: ['get']})
+  return mux(null, api, id)(session, {allow: ['get']})
 }
 
 function createClientAPI() {
@@ -93,7 +91,7 @@ tape('secure rpc', function (t) {
         t.ok(err); cb()
       }))
     }
-  ])(function (err) {
+  ])(function () {
     t.end()
   })
 

--- a/test/missing.js
+++ b/test/missing.js
@@ -1,16 +1,6 @@
 var pull = require('pull-stream')
 var mux = require('../')
 var tape = require('tape')
-var Pushable = require('pull-pushable')
-
-function delay(fun) {
-  return function (a, b) {
-    setImmediate(function () {
-      fun(a, b)
-    })
-  }
-}
-
 
 var client = {
   echo   : 'duplex',
@@ -27,17 +17,15 @@ tape('close after both sides of a duplex stream ends', function (t) {
   var bs = B.createStream()
   var as = A.createStream()
 
-  var source = Pushable()
-
   pull(
     function (err, cb) {
       if(!err) setTimeout(function () { cb(null, Date.now()) })
       else console.log('ERROR', err)
     },
-    A.echo(function (err) {
+    A.echo(function () {
       console.error('caught err')
     }),
-    pull.collect(function (err, ary) {
+    pull.collect(function (err) {
       t.ok(err)
       t.end()
     })

--- a/test/pull-weird.js
+++ b/test/pull-weird.js
@@ -13,9 +13,14 @@ tape('aborts pull-weird correctly', function (t) {
   t.plan(2)
   var ps = new PacketStream({})
 
+
   pull(
     function (abort, cb) {
-      if(abort) t.ok(true)
+      if(abort) {
+        t.ok(true)
+      } else {
+        cb('the stream must flow')
+      }
     },
     Weird(ps),
     function (read) {

--- a/util.js
+++ b/util.js
@@ -5,12 +5,6 @@ function isString (s) {
   return 'string' === typeof s
 }
 
-var isArray = Array.isArray
-
-function isObject (o) {
-  return o && 'object' === typeof o && !isArray(o)
-}
-
 function isEmpty (obj) {
   for(var k in obj) return false;
   return true
@@ -47,7 +41,7 @@ exports.get = function (obj, path) {
 }
 
 exports.prefix = function (obj, path) {
-  var value, parent = obj
+  var value
 
   for(var i = 0; i < path.length; i++) {
     var k = path[i]
@@ -55,11 +49,9 @@ exports.prefix = function (obj, path) {
     if('object' !== typeof obj) {
       return obj
     }
-    parent = obj
   }
   return 'object' !== typeof value ? !!value : false
 }
-
 
 function mkPath(obj, path) {
   for(var i in path) {
@@ -88,12 +80,12 @@ function merge (obj, _obj) {
   return obj
 }
 
-var mount = exports.mount = function (obj, path, _obj) {
+exports.mount = function (obj, path, _obj) {
   if(!Array.isArray(path))
     throw new Error('path must be array of strings')
   return merge(mkPath(obj, path), _obj)
 }
-var unmount = exports.unmount = function (obj, path) {
+exports.unmount = function (obj, path) {
   return rmPath(obj, path)
 }
 
@@ -103,7 +95,6 @@ function isDuplex    (t) { return 'duplex' === t }
 function isSync      (t) { return 'sync'  === t }
 function isAsync     (t) { return 'async'  === t }
 function isRequest   (t) { return isSync(t) || isAsync(t) }
-function isStream    (t) { return isSource(t) || isSink(t) || isDuplex(t) }
 
 function abortSink (err) {
   return function (read) {


### PR DESCRIPTION
The existing code has lots of unused variables and allocations (for both
the computer and the programmer) which end up being used.

This commit applies the default (largely uncontroversial) rule set from
ESLint (eslint:recommended) to ensure that we aren't shooting ourselves
in the foot anywhere. This has fixed at least two tests which were
suffering from variable shadowing problems.