### PR TITLE
protect packetstream.read against falsy input

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -47,6 +47,7 @@ module.exports = function initStream (localCall, codec, onClose) {
       stream.read = function (data, end) {
         //how would this actually happen?
         if(end) return stream.write(null, end)
+        if(!data) return stream.write(null, new Error("falsy data given to stream.read"))
 
         var name = data.name
         var type = data.type


### PR DESCRIPTION
## Context

In the stderr logs of one ssb-room server with muxrpc `6.5.0`, I found these, quite frequently:

```
2|ssb-room | TypeError: Cannot read property 'name' of null
2|ssb-room |     at PacketStreamSubstream.stream.read (/root/ssb-room/node_modules/muxrpc/stream.js:57:25)
2|ssb-room |     at PacketStream._onstream (/root/ssb-room/node_modules/packet-stream/index.js:224:13)
2|ssb-room |     at PacketStream.write (/root/ssb-room/node_modules/packet-stream/index.js:135:41)
2|ssb-room |     at /root/ssb-room/node_modules/muxrpc/pull-weird.js:56:15
2|ssb-room |     at /root/ssb-room/node_modules/pull-stream/sinks/drain.js:24:37
2|ssb-room |     at /root/ssb-room/node_modules/pull-goodbye/node_modules/pull-stream/throughs/filter.js:17:11
2|ssb-room |     at Object.cb (/root/ssb-room/node_modules/packet-stream-codec/index.js:111:11)
2|ssb-room |     at drain (/root/ssb-room/node_modules/pull-reader/index.js:39:14)
2|ssb-room |     at more (/root/ssb-room/node_modules/pull-reader/index.js:55:13)
2|ssb-room |     at /root/ssb-room/node_modules/pull-reader/index.js:66:9
```

## Problem

I did a search for `.name` in any of the modules, and found that one of the cases was in muxrpc. I put a console.log if `data` was falsy, and then re-ran the server and saw that console.log, which confirms that this code was not protected for cases where `data` is undefined and we try to access `data.name`.

## Solution

If `data` is undefined, return an error instead of crashing Node.js.