### PR TITLE
use standard for linting and code style

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,75 +1,77 @@
 'use strict'
-var PSC          = require('packet-stream-codec')
-var initStream   = require('./stream')
-var createRemoteApi    = require('./remote-api')
-var createLocalApi = require('./local-api')
-var EventEmitter = require('events').EventEmitter
+const PSC = require('packet-stream-codec')
+const initStream = require('./stream')
+const createRemoteApi = require('./remote-api')
+const createLocalApi = require('./local-api')
+const EventEmitter = require('events').EventEmitter
 
 function createMuxrpc (remoteManifest, localManifest, localApi, id, perms, codec, legacy) {
-  var bootstrap
-  if ('function' === typeof remoteManifest) {
+  let bootstrap
+  if (typeof remoteManifest === 'function') {
     bootstrap = remoteManifest
     remoteManifest = {}
   }
 
   localManifest = localManifest || {}
   remoteManifest = remoteManifest || {}
-  var emitter = new EventEmitter()
-  if(!codec) codec = PSC
+  const emitter = new EventEmitter()
+  if (!codec) codec = PSC
 
-  //pass the manifest to the permissions so that it can know
-  //what something should be.
-  var _cb
-  var context = {
-      _emit: function (event, value) {
-        emitter && emitter._emit(event, value)
-        return context
-      },
-      id: id
-    }
+  // pass the manifest to the permissions so that it can know
+  // what something should be.
+  let _cb
+  const context = {
+    _emit: function (event, value) {
+      emitter && emitter._emit(event, value)
+      return context
+    },
+    id: id
+  }
 
-  var ws = initStream(
+  const ws = initStream(
     createLocalApi(localApi, localManifest, perms).bind(context),
     codec, function (err) {
-      if(emitter.closed) return
+      if (emitter.closed) return
       emitter.closed = true
       emitter.emit('closed')
-      if(_cb) {
-        var cb = _cb; _cb = null; cb(err)
+      if (_cb) {
+        const cb = _cb
+        _cb = null
+        cb(err)
       }
     }
   )
 
   createRemoteApi(emitter, remoteManifest, function (type, name, args, cb) {
-    if(ws.closed) throw new Error('stream is closed')
+    if (ws.closed) throw new Error('stream is closed')
     return ws.remoteCall(type, name, args, cb)
   }, bootstrap)
 
-  //legacy local emit, from when remote emit was supported.
+  // legacy local emit, from when remote emit was supported.
   emitter._emit = emitter.emit
 
-  if(legacy) {
+  if (legacy) {
     Object.__defineGetter__.call(emitter, 'id', function () {
       return context.id
     })
 
     Object.__defineSetter__.call(emitter, 'id', function (value) {
-      context.id =  value
+      context.id = value
     })
 
-    var first = true
+    let first = true
 
     emitter.createStream = function (cb) {
       _cb = cb
-      if(first) {
+      if (first) {
         first = false; return ws
-      }
-      else
+      } else {
         throw new Error('one stream per rpc')
+      }
     }
-  }
-  else
+  } else {
     emitter.stream = ws
+  }
 
   emitter.closed = false
 
@@ -82,8 +84,9 @@ function createMuxrpc (remoteManifest, localManifest, localApi, id, perms, codec
 }
 
 module.exports = function (remoteManifest, localManifest, codec) {
-  if(arguments.length > 3)
+  if (arguments.length > 3) {
     return createMuxrpc.apply(this, arguments)
+  }
   return function (local, perms, id) {
     return createMuxrpc(remoteManifest, localManifest, local, id, perms, codec, true)
   }

--- a/local-api.js
+++ b/local-api.js
@@ -1,40 +1,43 @@
+'use strict'
+const Permissions = require('./permissions')
+const u = require('./util')
 
-var Permissions  = require('./permissions')
-var u            = require('./util')
-
-module.exports = 
-
-function createLocalCall(api, manifest, perms) {
+module.exports = function createLocalCall (api, manifest, perms) {
   perms = Permissions(perms)
 
-  function has(type, name) {
+  function has (type, name) {
     return type === u.get(manifest, name)
   }
 
-  function localCall(type, name, args) {
-
-    if(name === 'emit')
+  function localCall (type, name, args) {
+    if (name === 'emit') {
       throw new Error('emit has been removed')
+    }
 
-    //is there a way to know whether it's sync or async?
-    if(type === 'async')
-      if(has('sync', name)) {
-        var cb = args.pop(), value
-        try { value = u.get(api, name).apply(this, args) }
-        catch (err) { return cb(err) }
+    // is there a way to know whether it's sync or async?
+    if (type === 'async') {
+      if (has('sync', name)) {
+        const cb = args.pop()
+        let value
+        try {
+          value = u.get(api, name).apply(this, args)
+        } catch (err) {
+          return cb(err)
+        }
         return cb(null, value)
       }
+    }
 
-    if (!has(type, name))
-      throw new Error('no '+type+':'+name)
+    if (!has(type, name)) {
+      throw new Error('no ' + type + ':' + name)
+    }
 
     return u.get(api, name).apply(this, args)
   }
 
   return function (type, name, args) {
-    var err = perms.pre(name, args)
-    if(err) throw err
+    const err = perms.pre(name, args)
+    if (err) throw err
     return localCall.call(this, type, name, args)
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -21,14 +21,17 @@
     "pull-pair": "~1.0.0",
     "pull-pushable": "^1.1.4",
     "pull-serializer": "~0.2.0",
+    "standardx": "^7.0.0",
     "tap-bail": "^1.0.0",
     "tap-spec": "^5.0.0",
     "tape": "~5.2.2"
   },
   "scripts": {
     "prepublishOnly": "npm ls && npm test",
-    "test": "tape test/*.js | tap-bail | tap-spec",
-    "test-verbose": "TEST_VERBOSE=1 tape test/*.js | tap-bail | tap-spec"
+    "tape": "tape test/*.js | tap-bail | tap-spec",
+    "test": "standardx '**/*.js' && npm run tape",
+    "test-verbose": "TEST_VERBOSE=1 npm test",
+    "lint": "standardx --fix '**/*.js'"
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "license": "MIT"

--- a/permissions.js
+++ b/permissions.js
@@ -1,13 +1,13 @@
-'use strict';
-var u = require('./util')
+'use strict'
+const u = require('./util')
 
-var isArray = Array.isArray
+const isArray = Array.isArray
 
 function isFunction (f) {
-  return 'function' === typeof f
+  return typeof f === 'function'
 }
 
-function toArray(str) {
+function toArray (str) {
   return isArray(str) ? str : str.split('.')
 }
 
@@ -53,54 +53,55 @@ create perms:
 */
 
 module.exports = function (opts) {
-  if(isPerms(opts)) return opts
-  if(isFunction(opts)) return {pre: opts}
-  var allow = null
-  var deny = {}
+  if (isPerms(opts)) return opts
+  if (isFunction(opts)) return { pre: opts }
+  let allow = null
+  let deny = {}
 
   function perms (opts) {
-    if(opts.allow) {
+    if (opts.allow) {
       allow = {}
       opts.allow.forEach(function (path) {
         u.set(allow, toArray(path), true)
       })
-    }
-    else allow = null
+    } else allow = null
 
-    if(opts.deny)
+    if (opts.deny) {
       opts.deny.forEach(function (path) {
         u.set(deny, toArray(path), true)
       })
-    else deny = {}
+    } else {
+      deny = {}
+    }
 
     return this
   }
 
-  if(opts) perms(opts)
+  if (opts) perms(opts)
 
   perms.pre = function (name) {
     name = isArray(name) ? name : [name]
-    if(allow && !u.prefix(allow, name))
-      return new Error('method:'+name + ' is not in list of allowed methods')
+    if (allow && !u.prefix(allow, name)) {
+      return new Error('method:' + name + ' is not in list of allowed methods')
+    }
 
-    if(deny && u.prefix(deny, name))
-      return new Error('method:'+name + ' is on list of disallowed methods')
+    if (deny && u.prefix(deny, name)) {
+      return new Error('method:' + name + ' is on list of disallowed methods')
+    }
   }
 
   perms.post = function () {
-    //TODO
+    // TODO
   }
 
-  //alias for pre, used in tests.
+  // alias for pre, used in tests.
   perms.test = function (name) {
     return perms.pre(name)
   }
 
   perms.get = function () {
-    return {allow: allow, deny: deny}
+    return { allow: allow, deny: deny }
   }
 
   return perms
 }
-
-

--- a/stream.js
+++ b/stream.js
@@ -142,8 +142,8 @@ module.exports = function initStream (localCall, codec, onClose) {
       return
     }
     if (err) {
-      if (cb) cb()
       ps.destroy(err)
+      if (cb) cb()
       return
     }
 

--- a/test/async.js
+++ b/test/async.js
@@ -1,43 +1,42 @@
-var tape = require('tape')
-var pull = require('pull-stream')
-var pushable = require('pull-pushable')
-var mux = require('../')
+const tape = require('tape')
+const pull = require('pull-stream')
+const pushable = require('pull-pushable')
+const mux = require('../')
 
-module.exports = function(serializer, buffers) {
+module.exports = function (serializer, buffers) {
+  const b = buffers
+    ? function (b) {
+        return (
+          Buffer.isBuffer(b)
+          // reserialize, to take into the account
+          // changes Buffer#toJSON between 0.10 and 0.12
+            ? JSON.parse(JSON.stringify(b))
+            : b
+        )
+      }
+    : function (b) { return b }
 
-  var b = buffers
-  ? function (b) {
-    return (
-        Buffer.isBuffer(b)
-        //reserialize, to take into the account
-        //changes Buffer#toJSON between 0.10 and 0.12
-      ? JSON.parse(JSON.stringify(b))
-      : b
-    )
-  }
-  : function (b) { return b }
-
-  var client = {
-    hello  : 'async',
+  const client = {
+    hello: 'async',
     goodbye: 'async',
-    stuff  : 'source',
-    bstuff : 'source',
-    things : 'sink',
+    stuff: 'source',
+    bstuff: 'source',
+    things: 'sink',
     suchstreamwow: 'duplex'
   }
 
   tape('async', function (t) {
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       hello: function (a, cb) {
-        cb(null, 'hello, '+a)
+        cb(null, 'hello, ' + a)
       },
-      goodbye: function(b, cb) {
+      goodbye: function (b, cb) {
         cb(null, b)
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log) : null,
@@ -47,11 +46,11 @@ module.exports = function(serializer, buffers) {
     )
 
     A.hello('world', function (err, value) {
-      if(err) throw err
+      if (err) throw err
       if (process.env.TEST_VERBOSE) console.log(value)
       t.equal(value, 'hello, world')
 
-      var buf = Buffer.from([0, 1, 2, 3, 4])
+      const buf = Buffer.from([0, 1, 2, 3, 4])
       A.goodbye(buf, function (err, buf2) {
         if (err) throw err
         if (process.env.TEST_VERBOSE) console.log(b(buf2), b(buf))
@@ -62,17 +61,17 @@ module.exports = function(serializer, buffers) {
   })
 
   tape('async promise', function (t) {
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       hello: function (a, cb) {
-        cb(null, 'hello, '+a)
+        cb(null, 'hello, ' + a)
       },
-      goodbye: function(b, cb) {
+      goodbye: function (b, cb) {
         cb(null, b)
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log) : null,
@@ -85,7 +84,7 @@ module.exports = function(serializer, buffers) {
       if (process.env.TEST_VERBOSE) console.log(value)
       t.equal(value, 'hello, world')
 
-      var buf = Buffer.from([0, 1, 2, 3, 4])
+      const buf = Buffer.from([0, 1, 2, 3, 4])
       A.goodbye(buf).then((buf2) => {
         if (process.env.TEST_VERBOSE) console.log(b(buf2), b(buf))
         t.deepEqual(b(buf2), b(buf))
@@ -95,26 +94,25 @@ module.exports = function(serializer, buffers) {
   })
 
   tape('source', function (t) {
+    const expected = [
+      Buffer.from([0, 1]),
+      Buffer.from([2, 3]),
+      Buffer.from([4, 5])
+    ]
 
-    var expected = [
-          Buffer.from([0, 1]),
-          Buffer.from([2, 3]),
-          Buffer.from([4, 5])
-        ]
-
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       stuff: function (b) {
         return pull.values([1, 2, 3, 4, 5].map(function (a) {
           return a * b
         }))
       },
-      bstuff: function() {
+      bstuff: function () {
         return pull.values(expected)
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log) : null,
@@ -124,56 +122,53 @@ module.exports = function(serializer, buffers) {
     )
 
     pull(A.stuff(5), pull.collect(function (err, ary) {
-      if(err) throw err
+      if (err) throw err
       if (process.env.TEST_VERBOSE) console.log(ary)
       t.deepEqual(ary, [5, 10, 15, 20, 25])
 
-      pull(A.bstuff(), pull.collect(function(err, ary) {
+      pull(A.bstuff(), pull.collect(function (err, ary) {
         if (err) throw err
         if (process.env.TEST_VERBOSE) console.log(ary.map(b), expected.map(b))
         t.deepEqual(ary.map(b), expected.map(b))
         t.end()
       }))
     }))
-
   })
 
   tape('sync', function (t) {
-    var client = {
-      syncOk : 'sync',
+    const client = {
+      syncOk: 'sync',
       syncErr: 'sync'
     }
 
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       syncOk: function (a) {
-        return {okay: a}
+        return { okay: a }
       },
-      syncErr: function(b) {
-        throw new Error('test error:'+b)
+      syncErr: function (b) {
+        throw new Error('test error:' + b)
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(s, B.createStream(), s)
 
     A.syncOk(true, function (err, value) {
-      t.deepEqual(value, {okay: true})
+      t.error(err)
+      t.deepEqual(value, { okay: true })
       A.syncErr('blah', function (err) {
         t.equal(err.message, 'test error:blah')
         t.end()
-
       })
     })
-
   })
 
   tape('sink', function (t) {
-
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       things: function (someParam) {
-        return pull.collect(function(err, values) {
+        return pull.collect(function (err, values) {
           if (err) throw err
           t.equal(someParam, 5)
           t.deepEqual(values, [1, 2, 3, 4, 5])
@@ -182,7 +177,7 @@ module.exports = function(serializer, buffers) {
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log) : null,
@@ -190,13 +185,12 @@ module.exports = function(serializer, buffers) {
       process.env.TEST_VERBOSE ? pull.through(console.log) : null,
       s
     )
-    pull(pull.values([1,2,3,4,5]), A.things(5))
+    pull(pull.values([1, 2, 3, 4, 5]), A.things(5))
   })
 
   tape('duplex', function (t) {
-
-    var A = mux(client, null, serializer) ()
-    var B = mux(null, client, serializer) ({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       suchstreamwow: function (someParam) {
         // did the param come through?
         t.equal(someParam, 5)
@@ -204,24 +198,24 @@ module.exports = function(serializer, buffers) {
         // normally, we'd use pull.values and pull.collect
         // however, pull.values sends 'end' onto the stream, which closes the muxrpc stream immediately
         // ...and we need the stream to stay open for the drain to collect
-        var nextValue = 0
-        var p = pushable()
-        for (var i=0; i < 5; i++)
-          p.push(i)
+        let nextValue = 0
+        const p = pushable()
+        for (let i = 0; i < 5; i++) { p.push(i) }
         return {
           source: p,
-          sink: pull.drain(function(value) {
+          sink: pull.drain(function (value) {
             if (process.env.TEST_VERBOSE) console.log('************', nextValue, value)
             t.equal(nextValue, value)
             nextValue++
-            if (nextValue == 5)
+            if (nextValue === 5) {
               t.end()
+            }
           })
         }
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log.bind(console, 'IN')) : null,
@@ -229,27 +223,30 @@ module.exports = function(serializer, buffers) {
       process.env.TEST_VERBOSE ? pull.through(console.log.bind(console, 'OUT')) : null,
       s
     )
-    var dup = A.suchstreamwow(5)
+    const dup = A.suchstreamwow(5)
     pull(dup, dup)
   })
 
   tape('async - error1', function (t) {
-    var A = mux(client, null) ()
+    const A = mux(client, null)()
 
-    var s = A.createStream()
+    const s = A.createStream()
 
     A.hello('world', function (err) {
       t.ok(err)
       t.end()
     })
 
-    s.sink(function (abort, cb) { cb(true) })
+    s.sink(function (abort, cb) {
+      const errEnd = true
+      cb(errEnd)
+    })
   })
 
   tape('async - error2', function (t) {
-    var A = mux(client, null) ()
+    const A = mux(client, null)()
 
-    var s = A.createStream()
+    const s = A.createStream()
 
     A.hello('world', function (err) {
       if (process.env.TEST_VERBOSE) console.log('CB!')
@@ -261,71 +258,67 @@ module.exports = function(serializer, buffers) {
   })
 
   tape('buffer calls before stream is created', function (t) {
-    var A = mux(client, null) ()
-    var B = mux(null, client) ({
+    const A = mux(client, null)()
+    const B = mux(null, client)({
       hello: function (a, cb) {
-        cb(null, 'hello, '+a)
-      },
+        cb(null, 'hello, ' + a)
+      }
     })
 
     A.hello('world', function (err, value) {
-      if(err) throw err
+      if (err) throw err
       if (process.env.TEST_VERBOSE) console.log(value)
       t.equal(value, 'hello, world')
       t.end()
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(s, B.createStream(), s)
-
   })
 
-//  tape('async - error, and reconnect', function (t) {
-//    var A = mux(client, null) ()
-//
-//    var s = A.createStream()
-//
-//    A.hello('world', function (err, value) {
-//      t.ok(err)
-//
-//      var B = mux(null, client) ({
-//        hello: function (a, cb) {
-//          cb(null, 'hello, '+a)
-//        },
-//      })
-//
-//      var s = A.createStream()
-//
-//      pull(s, B.createStream(), s)
-//
-//      A.hello('world', function (err, value) {
-//        t.notOk(err)
-//        t.equal(value, 'hello, world')
-//        t.end()
-//      })
-//    })
-//
-//    s.sink(function (abort, cb) { cb(true) })
-//  })
+  //  tape('async - error, and reconnect', function (t) {
+  //    var A = mux(client, null) ()
+  //
+  //    var s = A.createStream()
+  //
+  //    A.hello('world', function (err, value) {
+  //      t.ok(err)
+  //
+  //      var B = mux(null, client) ({
+  //        hello: function (a, cb) {
+  //          cb(null, 'hello, '+a)
+  //        },
+  //      })
+  //
+  //      var s = A.createStream()
+  //
+  //      pull(s, B.createStream(), s)
+  //
+  //      A.hello('world', function (err, value) {
+  //        t.notOk(err)
+  //        t.equal(value, 'hello, world')
+  //        t.end()
+  //      })
+  //    })
+  //
+  //    s.sink(function (abort, cb) { cb(true) })
+  //  })
 
   tape('recover error written to outer stream', function (t) {
-
-    var A = mux(client, null) ()
-    var err = new Error('testing errors')
-    var s = A.createStream(function (_err) {
+    const A = mux(client, null)()
+    const err = new Error('testing errors')
+    const s = A.createStream(function (_err) {
       t.equal(_err, err)
       t.end()
     })
 
     pull(pull.error(err), s.sink)
-
   })
 
   tape('recover error when outer stream aborted', function (t) {
-
-    var A = mux(client, null) ()
-    var err = new Error('testing errors')
-    var s = A.createStream(function (_err) {
+    const A = mux(client, null)()
+    const err = new Error('testing errors')
+    const s = A.createStream(function (_err) {
       t.equal(_err, err)
       t.end()
     })
@@ -334,33 +327,31 @@ module.exports = function(serializer, buffers) {
   })
 
   tape('cb when stream is ended', function (t) {
-
-    var A = mux(client, null) ()
-    var s = A.createStream(function (err) {
-//      if(err) throw err
+    const A = mux(client, null)()
+    const s = A.createStream(function (err) {
+      //      if(err) throw err
       t.ok(err)
-//      t.equal(err, null)
+      //      t.equal(err, null)
       t.end()
     })
 
     pull(pull.empty(), s.sink)
-
   })
 
   tape('cb when stream is aborted', function (t) {
-    var err = new Error('testing error')
-    var A = mux(client, null) ()
-    var s = A.createStream(function (_err) {
-  //    if(_err) throw err
+    const err = new Error('testing error')
+    const A = mux(client, null)()
+    const s = A.createStream(function (_err) {
+      //    if(_err) throw err
       t.equal(_err, err)
-//      t.ok(err)
+      //      t.ok(err)
       t.end()
     })
 
     s.source(err, function () {})
   })
 
-  var client2 = {
+  const client2 = {
     salutations: {
       hello: 'async',
       goodbye: 'async'
@@ -368,19 +359,19 @@ module.exports = function(serializer, buffers) {
   }
 
   tape('nested methods', function (t) {
-    var A = mux(client2, null, serializer) ()
-    var B = mux(null, client2, serializer) ({
+    const A = mux(client2, null, serializer)()
+    const B = mux(null, client2, serializer)({
       salutations: {
         hello: function (a, cb) {
-          cb(null, 'hello, '+a)
+          cb(null, 'hello, ' + a)
         },
-        goodbye: function(b, cb) {
+        goodbye: function (b, cb) {
           cb(null, b)
         }
       }
     })
 
-    var s = A.createStream()
+    const s = A.createStream()
     pull(
       s,
       process.env.TEST_VERBOSE ? pull.through(console.log.bind(console, 'IN')) : null,
@@ -390,43 +381,43 @@ module.exports = function(serializer, buffers) {
     )
 
     A.salutations.hello('world', function (err, value) {
-      if(err) throw err
+      if (err) throw err
       if (process.env.TEST_VERBOSE) console.log(value)
       t.equal(value, 'hello, world')
 
-      var buf = Buffer.from([0, 1, 2, 3, 4])
+      const buf = Buffer.from([0, 1, 2, 3, 4])
       A.salutations.goodbye(buf, function (err, buf2) {
         if (err) throw err
-        t.deepEqual( b(buf2), b(buf))
+        t.deepEqual(b(buf2), b(buf))
         t.end()
       })
     })
-
   })
 
   tape('sink', function (t) {
-    var A = mux(client, null, serializer)()
-    var B = mux(null, client, serializer)({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       things: function (len) {
         return pull.collect(function (err, ary) {
+          t.error(err)
           t.equal(ary.length, len)
         })
       }
     })
 
-    var s = A.createStream(); pull(s, B.createStream(), s)
+    const s = A.createStream(); pull(s, B.createStream(), s)
 
-    pull(pull.values([1,2,3]), A.things(3, function (err) {
-      if(err) throw err
+    pull(pull.values([1, 2, 3]), A.things(3, function (err) {
+      if (err) throw err
       t.end()
     }))
   })
 
   tape('sink - abort', function (t) {
-    var err = new Error('test abort error')
+    const err = new Error('test abort error')
 
-    var A = mux(client, null, serializer)()
-    var B = mux(null, client, serializer)({
+    const A = mux(client, null, serializer)()
+    const B = mux(null, client, serializer)({
       things: function () {
         return function (read) {
           read(err, function () {})
@@ -434,18 +425,15 @@ module.exports = function(serializer, buffers) {
       }
     })
 
-    var s = A.createStream(); pull(s, B.createStream(), s)
+    const s = A.createStream(); pull(s, B.createStream(), s)
 
-    pull(pull.values([1,2,3]), A.things(3, function (_err) {
+    pull(pull.values([1, 2, 3]), A.things(3, function (_err) {
       t.ok(_err)
       t.equal(_err.message, err.message)
       t.end()
     }))
-
   })
-
 }
 
-//see ./jsonb.js for tests with serialization.
-if(!module.parent)
-  module.exports(function (e) { return e });
+// see ./jsonb.js for tests with serialization.
+if (!module.parent) { module.exports(function (e) { return e }) }

--- a/test/attack.js
+++ b/test/attack.js
@@ -1,26 +1,24 @@
 
-
-var tape = require('tape')
-var mux = require('../')
-var pull = require('pull-stream')
-var pair = require('pull-pair')
+const tape = require('tape')
+const mux = require('../')
+const pull = require('pull-stream')
+const pair = require('pull-pair')
 
 function createClient (t) {
-
-  var client = {
-    get   : 'async',
-    read  : 'source',
-    write : 'sink',
-    echo  : 'duplex'
+  const client = {
+    get: 'async',
+    read: 'source',
+    write: 'sink',
+    echo: 'duplex'
   }
 
-  var A = mux(client, null) ()
+  const A = mux(client, null)()
 
-  var B = mux(null, {}) ({
+  const B = mux(null, {})({
     get: function (a, cb) {
-      //root access!! this should never happen!
+      // root access!! this should never happen!
       t.ok(false, 'attacker got in')
-      cb(null, "ACCESS GRANTED")
+      cb(null, 'ACCESS GRANTED')
     },
     read: function () {
       t.ok(false, 'attacker got in')
@@ -36,7 +34,7 @@ function createClient (t) {
     }
   })
 
-  var s = A.createStream()
+  const s = A.createStream()
   pull(
     s,
     process.env.TEST_VERBOSE ? pull.through(console.log) : null,
@@ -49,27 +47,24 @@ function createClient (t) {
 }
 
 tape('request which is not public', function (t) {
-
-  //create a client with a different manifest to the server.
-  //create a server that
+  // create a client with a different manifest to the server.
+  // create a server that
 
   const A = createClient(t)
 
   A.get('foo', function (err, val) {
     t.ok(err)
-    t.notEqual(val, "ACCESS GRANTED")
+    t.notEqual(val, 'ACCESS GRANTED')
     t.end()
   })
-
 })
 
 tape('sink which is not public', function (t) {
-
-  //create a client with a different manifest to the server.
-  var A = createClient(t)
+  // create a client with a different manifest to the server.
+  const A = createClient(t)
 
   pull(
-    pull.values(["ACCESS", "GRANTED"]),
+    pull.values(['ACCESS', 'GRANTED']),
     A.write(null, function (err) {
       t.ok(err)
       t.end()
@@ -78,43 +73,41 @@ tape('sink which is not public', function (t) {
 })
 
 tape('source which is not public', function (t) {
-
-  //create a client with a different manifest to the server.
-  var A = createClient(t)
+  // create a client with a different manifest to the server.
+  const A = createClient(t)
 
   pull(
     A.read(),
     pull.collect(function (err, ary) {
       t.ok(err)
-      t.notDeepEqual(ary, ["ACCESS", "GRANTED"])
+      t.notDeepEqual(ary, ['ACCESS', 'GRANTED'])
       t.end()
     })
   )
 })
 
 tape('duplex which is not public', function (t) {
-
-  //create a client with a different manifest to the server.
-  var A = createClient(t)
+  // create a client with a different manifest to the server.
+  const A = createClient(t)
 
   pull(
     A.read(),
     pull.collect(function (err, ary) {
       t.ok(err)
-      t.notDeepEqual(ary, ["ACCESS", "GRANTED"])
+      t.notDeepEqual(ary, ['ACCESS', 'GRANTED'])
       t.end()
     })
   )
 })
 
 tape('client and server manifest have different types', function (t) {
-  var clientM = { foo: 'async' }
-  var serverM = { foo: 'source' }
+  const clientM = { foo: 'async' }
+  const serverM = { foo: 'source' }
 
-  var A = mux(clientM, null) ()
-  var B = mux(null, serverM) ()
+  const A = mux(clientM, null)()
+  const B = mux(null, serverM)()
 
-  var as = A.createStream()
+  const as = A.createStream()
   pull(as, B.createStream(), as)
 
   A.foo(function (err) {

--- a/test/auth-perms.js
+++ b/test/auth-perms.js
@@ -1,21 +1,21 @@
-var tape = require('tape')
-var pull = require('pull-stream')
-var mux = require('../')
-var cont = require('cont')
-var Permissions = require('../permissions')
+const tape = require('tape')
+const pull = require('pull-stream')
+const mux = require('../')
+const cont = require('cont')
+const Permissions = require('../permissions')
 
-var api = {
-  login  : 'async',
-  logout : 'async',
-  get    : 'async',
-  put    : 'async',
-  del    : 'async',
-  read   : 'source',
+const api = {
+  login: 'async',
+  logout: 'async',
+  get: 'async',
+  put: 'async',
+  del: 'async',
+  read: 'source',
   nested: {
-    get    : 'async',
-    put    : 'async',
-    del    : 'async',
-    read   : 'source'
+    get: 'async',
+    put: 'async',
+    del: 'async',
+    read: 'source'
   }
 }
 
@@ -23,55 +23,49 @@ function id (e) {
   return e
 }
 
-var store = {
+const store = {
   foo: 1,
   bar: 2,
   baz: 3
 }
 
 function createServerAPI (store) {
-  var name = 'nobody'
+  let name = 'nobody'
 
-  //this wraps a session.
+  // this wraps a session.
 
-  var perms = Permissions({allow: ['login']})
+  const perms = Permissions({ allow: ['login'] })
 
-  var session = {
-    //implement your own auth function.
-    //it should just set the allow and deny lists.
+  const session = {
+    // implement your own auth function.
+    // it should just set the allow and deny lists.
 
     login: function (opts, cb) {
-      //allow read operations
-      if(opts.name === 'user' && opts.pass === "password")
-        perms({deny: ['put', 'del'], allow: null})
-
-      //allow write operations
-      else if(opts.name === 'admin' && opts.pass === "admin") //whatelse?
-        perms({deny: null, allow: null}) //allow everything
-
-      //
-      else if(opts.name === 'nested' && opts.pass === 'foofoo')
+      if (opts.name === 'user' && opts.pass === 'password') { // allow read operations
+        perms({ deny: ['put', 'del'], allow: null })
+      } else if (opts.name === 'admin' && opts.pass === 'admin') { // allow write operations
+        perms({ deny: null, allow: null })
+      } else if (opts.name === 'nested' && opts.pass === 'foofoo') { // allow everything
         perms({
-          //read only access to nested methods
+        // read only access to nested methods
           allow: ['nested'],
           deny: [['nested', 'put'], ['nested', 'del']]
         })
-
-      //you are nobody!
-      else
+      } else { // you are nobody!
         return cb(new Error('not authorized'))
+      }
 
       name = opts.name
 
-      cb(null, {okay: true, name: name})
+      cb(null, { okay: true, name: name })
     },
     logout: function (cb) {
       name = 'nobody'
-      perms({allow: ['login'], deny: null})
-      cb(null, {okay: true, user: name})
+      perms({ allow: ['login'], deny: null })
+      cb(null, { okay: true, user: name })
     },
     whoami: function (cb) {
-      cb(null, {okay: true, user: name})
+      cb(null, { okay: true, user: name })
     },
     get: function (key, cb) {
       return cb(null, store[key])
@@ -87,7 +81,7 @@ function createServerAPI (store) {
     read: function () {
       return pull.values(
         Object.keys(store).map(function (k) {
-          return {key: k, value: store[k]}
+          return { key: k, value: store[k] }
         })
       )
     }
@@ -98,17 +92,16 @@ function createServerAPI (store) {
   return mux(null, api, id)(session, perms)
 }
 
-function createClientAPI() {
+function createClientAPI () {
   return mux(api, null, id)()
 }
 
 tape('secure rpc', function (t) {
+  const server = createServerAPI(store)
+  const client = createClientAPI()
 
-  var server = createServerAPI(store)
-  var client = createClientAPI()
-
-  var ss = server.createStream()
-  var cs = client.createStream()
+  const ss = server.createStream()
+  const cs = client.createStream()
 
   pull(cs, ss, cs)
 
@@ -134,8 +127,8 @@ tape('secure rpc', function (t) {
       }))
     }
   ])(function () {
-    client.login({name: 'user', pass: 'password'}, function (err, res) {
-      if(err) throw err
+    client.login({ name: 'user', pass: 'password' }, function (err, res) {
+      if (err) throw err
       t.ok(res.okay)
       if (process.env.TEST_VERBOSE) console.log(res)
       t.equal(res.name, 'user')
@@ -143,7 +136,7 @@ tape('secure rpc', function (t) {
       cont.para([
         function (cb) {
           client.get('foo', function (err, value) {
-            if(err) throw err
+            if (err) throw err
             t.equal(value, 1)
             cb()
           })
@@ -160,70 +153,66 @@ tape('secure rpc', function (t) {
         },
         function (cb) {
           pull(client.read(), pull.collect(function (err, ary) {
-            if(err) throw err
+            if (err) throw err
             t.deepEqual(ary, [
-              {key: 'foo', value: 1},
-              {key: 'bar', value: 2},
-              {key: 'baz', value: 3},
+              { key: 'foo', value: 1 },
+              { key: 'bar', value: 2 },
+              { key: 'baz', value: 3 }
             ]); cb()
           }))
         }
       ])(function () {
-          t.end()
-        })
+        t.end()
+      })
     })
   })
-
 })
 
 tape('multiple sessions at once', function (t) {
+  const server1 = createServerAPI(store)
+  const server2 = createServerAPI(store)
+  const admin = createClientAPI()
+  const user = createClientAPI()
 
-  var server1 = createServerAPI(store)
-  var server2 = createServerAPI(store)
-  var admin   = createClientAPI()
-  var user    = createClientAPI()
-
-  var s1s = server1.createStream()
-  var s2s = server2.createStream()
-  var us = user.createStream()
-  var as = admin.createStream()
+  const s1s = server1.createStream()
+  const s2s = server2.createStream()
+  const us = user.createStream()
+  const as = admin.createStream()
 
   pull(us, s1s, us)
   pull(as, s2s, as)
 
   cont.para([
     function (cb) {
-      user.login({name: 'user', pass: 'password'}, cb)
+      user.login({ name: 'user', pass: 'password' }, cb)
     },
     function (cb) {
-      admin.login({name: 'admin', pass: 'admin'}, cb)
+      admin.login({ name: 'admin', pass: 'admin' }, cb)
     }
   ])(function (err) {
-    if(err) throw err
+    if (err) throw err
 
     user.get('foo', function (err, value) {
-      if(err) throw err
+      if (err) throw err
       t.equal(value, 1)
       admin.put('foo', 2, function (err) {
-        if(err) throw err
+        if (err) throw err
         user.get('foo', function (err, value) {
-          if(err) throw err
+          if (err) throw err
           t.equal(value, 2)
           t.end()
         })
       })
     })
-
   })
-
 })
 
 tape('nested sessions', function (t) {
-  var server = createServerAPI(store)
-  var client = createClientAPI()
+  const server = createServerAPI(store)
+  const client = createClientAPI()
 
-  var ss = server.createStream()
-  var cs = client.createStream()
+  const ss = server.createStream()
+  const cs = client.createStream()
 
   pull(cs, ss, cs)
 
@@ -249,11 +238,11 @@ tape('nested sessions', function (t) {
       }))
     }
   ])(function () {
-    client.login({name: 'nested', pass: 'foofoo'}, function () {
+    client.login({ name: 'nested', pass: 'foofoo' }, function () {
       cont.para([
         function (cb) {
           client.nested.get('foo', function (err, value) {
-            if(err) throw err
+            if (err) throw err
             t.equal(value, 2, 'foo should be 2')
             cb()
           })
@@ -270,19 +259,17 @@ tape('nested sessions', function (t) {
         },
         function (cb) {
           pull(client.nested.read(), pull.collect(function (err, ary) {
-            if(err) throw err
+            if (err) throw err
             t.deepEqual(ary, [
-              {key: 'foo', value: 2},
-              {key: 'bar', value: 2},
-              {key: 'baz', value: 3},
+              { key: 'foo', value: 2 },
+              { key: 'bar', value: 2 },
+              { key: 'baz', value: 3 }
             ]); cb()
           }))
         }
       ])(function () {
-
-          t.end()
-        })
+        t.end()
+      })
     })
   })
-
 })

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,11 +1,11 @@
-var pull = require('pull-stream')
-var tape = require('tape')
-var Muxrpc = require('../')
+const pull = require('pull-stream')
+const tape = require('tape')
+const Muxrpc = require('../')
 
-var manifest = { hello: 'sync', manifest: 'sync' }
-var api = {
+const manifest = { hello: 'sync', manifest: 'sync' }
+const api = {
   hello: function (n) {
-    if(this._emit) this._emit('hello', n)
+    if (this._emit) this._emit('hello', n)
     if (process.env.TEST_VERBOSE) console.log('hello from ' + this.id)
     return n + ':' + this.id
   },
@@ -15,18 +15,17 @@ var api = {
 }
 
 tape('emit an event from the called api function', function (t) {
-
   t.plan(6)
 
-  var bob = Muxrpc(null, manifest)  (api)
-  var cb = function (err, val, emitter) {
+  const bob = Muxrpc(null, manifest)(api)
+  const cb = function (err, val, emitter) {
     t.notOk(err)
     t.deepEqual(manifest, val)
     t.ok(emitter)
   }
 
-  var alice = Muxrpc(cb) ()
-  var as = alice.createStream()
+  const alice = Muxrpc(cb)()
+  const as = alice.createStream()
   pull(as, bob.createStream(), as)
 
   bob.id = 'Alice'

--- a/test/initial-perms-bootstrap.js
+++ b/test/initial-perms-bootstrap.js
@@ -1,18 +1,18 @@
-var tape = require('tape')
-var pull = require('pull-stream')
-var mux = require('../')
-var cont = require('cont')
+const tape = require('tape')
+const pull = require('pull-stream')
+const mux = require('../')
+const cont = require('cont')
 
-var api = {
-  get    : 'async',
-  put    : 'async',
-  del    : 'async',
-  read   : 'source',
+const api = {
+  get: 'async',
+  put: 'async',
+  del: 'async',
+  read: 'source',
   nested: {
-    get    : 'async',
-    put    : 'async',
-    del    : 'async',
-    read   : 'source',
+    get: 'async',
+    put: 'async',
+    del: 'async',
+    read: 'source'
   },
   manifest: 'sync'
 }
@@ -21,20 +21,20 @@ function id (e) {
   return e
 }
 
-var store = {
+const store = {
   foo: 1,
   bar: 2,
   baz: 3
 }
 
 function createServerAPI (store) {
-  var name = 'nobody'
+  const name = 'nobody'
 
-  //this wraps a session.
+  // this wraps a session.
 
-  var session = {
+  const session = {
     whoami: function (cb) {
-      cb(null, {okay: true, user: name})
+      cb(null, { okay: true, user: name })
     },
     get: function (key, cb) {
       return cb(null, store[key])
@@ -48,7 +48,7 @@ function createServerAPI (store) {
       cb()
     },
     read: function () {
-      return pull.values([1,2,3])
+      return pull.values([1, 2, 3])
     },
     manifest: function () {
       return api
@@ -57,16 +57,15 @@ function createServerAPI (store) {
 
   session.nested = session
 
-  return mux(null, api, id)(session, {allow: ['manifest', 'get']})
+  return mux(null, api, id)(session, { allow: ['manifest', 'get'] })
 }
 
-function createClientAPI(cb) {
+function createClientAPI (cb) {
   return mux(cb, null, id)()
 }
 
 tape('secure rpc', function (t) {
-
-  var afterBootstrap = function () {
+  const afterBootstrap = function () {
     cont.para([
       function (cb) {
         client.get('foo', function (err) {
@@ -93,11 +92,11 @@ tape('secure rpc', function (t) {
     })
   }
 
-  var server = createServerAPI(store)
-  var client = createClientAPI(afterBootstrap)
+  const server = createServerAPI(store)
+  const client = createClientAPI(afterBootstrap)
 
-  var ss = server.createStream()
-  var cs = client.createStream()
+  const ss = server.createStream()
+  const cs = client.createStream()
 
   pull(cs, ss, cs)
 })

--- a/test/initial-perms.js
+++ b/test/initial-perms.js
@@ -1,18 +1,18 @@
-var tape = require('tape')
-var pull = require('pull-stream')
-var mux = require('../')
-var cont = require('cont')
+const tape = require('tape')
+const pull = require('pull-stream')
+const mux = require('../')
+const cont = require('cont')
 
-var api = {
-  get    : 'async',
-  put    : 'async',
-  del    : 'async',
-  read   : 'source',
+const api = {
+  get: 'async',
+  put: 'async',
+  del: 'async',
+  read: 'source',
   nested: {
-    get    : 'async',
-    put    : 'async',
-    del    : 'async',
-    read   : 'source',
+    get: 'async',
+    put: 'async',
+    del: 'async',
+    read: 'source'
   }
 }
 
@@ -20,20 +20,20 @@ function id (e) {
   return e
 }
 
-var store = {
+const store = {
   foo: 1,
   bar: 2,
   baz: 3
 }
 
 function createServerAPI (store) {
-  var name = 'nobody'
+  const name = 'nobody'
 
-  //this wraps a session.
+  // this wraps a session.
 
-  var session = {
+  const session = {
     whoami: function (cb) {
-      cb(null, {okay: true, user: name})
+      cb(null, { okay: true, user: name })
     },
     get: function (key, cb) {
       return cb(null, store[key])
@@ -47,26 +47,25 @@ function createServerAPI (store) {
       cb()
     },
     read: function () {
-      return pull.values([1,2,3])
+      return pull.values([1, 2, 3])
     }
   }
 
   session.nested = session
 
-  return mux(null, api, id)(session, {allow: ['get']})
+  return mux(null, api, id)(session, { allow: ['get'] })
 }
 
-function createClientAPI() {
+function createClientAPI () {
   return mux(api, null, id)()
 }
 
 tape('secure rpc', function (t) {
+  const server = createServerAPI(store)
+  const client = createClientAPI()
 
-  var server = createServerAPI(store)
-  var client = createClientAPI()
-
-  var ss = server.createStream()
-  var cs = client.createStream()
+  const ss = server.createStream()
+  const cs = client.createStream()
 
   pull(cs, ss, cs)
 
@@ -94,7 +93,4 @@ tape('secure rpc', function (t) {
   ])(function () {
     t.end()
   })
-
 })
-
-

--- a/test/jsonb.js
+++ b/test/jsonb.js
@@ -1,7 +1,7 @@
-var PullSerializer = require('pull-serializer')
-var JSONB = require('json-buffer')
+const PullSerializer = require('pull-serializer')
+const JSONB = require('json-buffer')
 // run tests with jsonb serialization
-var codec = function(stream) {
+const codec = function (stream) {
   return PullSerializer(stream, JSONB)
 }
 
@@ -9,8 +9,8 @@ require('./async')(codec)
 
 // YOLO
 
-//require('./abort')(codec)
-//require('./closed')(codec)
-//require('./emit')(codec)
-//require('./stream-end')(codec)
+// require('./abort')(codec)
+// require('./closed')(codec)
+// require('./emit')(codec)
+// require('./stream-end')(codec)
 //

--- a/test/missing.js
+++ b/test/missing.js
@@ -1,51 +1,39 @@
-var pull = require('pull-stream')
-var mux = require('../')
-var tape = require('tape')
+const pull = require('pull-stream')
+const mux = require('../')
+const tape = require('tape')
 
-var client = {
-  echo   : 'duplex',
+const client = {
+  echo: 'duplex'
 }
 
 module.exports = function (codec) {
+  tape('close after both sides of a duplex stream ends', function (t) {
+    const A = mux(client, null, codec)()
+    const B = mux(null, client, codec)({
+    })
 
-tape('close after both sides of a duplex stream ends', function (t) {
+    const bs = B.createStream()
+    const as = A.createStream()
 
-  var A = mux(client, null, codec) ()
-  var B = mux(null, client, codec) ({
+    pull(
+      function (err, cb) {
+        if (!err) setTimeout(function () { cb(null, Date.now()) })
+        else if (process.env.TEST_VERBOSE) console.log('ERROR', err)
+      },
+      A.echo(function () {
+        if (process.env.TEST_VERBOSE) console.error('caught err')
+      }),
+      pull.collect(function (err) {
+        t.ok(err)
+        t.end()
+      })
+    )
+
+    pull(as, bs, as)
   })
 
-  var bs = B.createStream()
-  var as = A.createStream()
-
-  pull(
-    function (err, cb) {
-      if(!err) setTimeout(function () { cb(null, Date.now()) })
-      else if (process.env.TEST_VERBOSE) console.log('ERROR', err)
-    },
-    A.echo(function () {
-      if (process.env.TEST_VERBOSE) console.error('caught err')
-    }),
-    pull.collect(function (err) {
-      t.ok(err)
-      t.end()
-    })
-  )
-
-  pull(as, bs, as)
-
-})
-
-//TODO: write test for when it's a duplex api that
-//is missing on the remote!!!
-
+  // TODO: write test for when it's a duplex api that
+  // is missing on the remote!!!
 }
 
-if(!module.parent) module.exports(function (e) { return e })
-
-
-
-
-
-
-
-
+if (!module.parent) module.exports(function (e) { return e })

--- a/test/mount.js
+++ b/test/mount.js
@@ -1,79 +1,71 @@
 
-var tape = require('tape')
-var m = require('../util')
-var mount = m.mount
-var unmount = m.unmount
+const tape = require('tape')
+const m = require('../util')
+const mount = m.mount
+const unmount = m.unmount
 
 tape('mount manifest at root', function (t) {
+  const manf = {}
 
-  var manf = {}
+  mount(manf, [], { thing: 'async' })
 
-  mount(manf, [], {thing: 'async'})
+  t.deepEqual(manf, { thing: 'async' })
 
-  t.deepEqual(manf, {thing: 'async'})
+  mount(manf, ['foo'], { thing: 'async' })
 
-  mount(manf, ['foo'], {thing: 'async'})
-
-  t.deepEqual(manf, {thing: 'async', foo: {thing: 'async'}})
+  t.deepEqual(manf, { thing: 'async', foo: { thing: 'async' } })
 
   t.end()
 })
 
 tape('without mount without path should throw', function (t) {
-
   t.throws(function () {
-    mount({}, {thing: 'async'})
+    mount({}, { thing: 'async' })
   })
 
   t.end()
 })
 
 tape('unmount', function (t) {
-  var manf = {}
+  const manf = {}
 
-  mount(manf, ['foo'], {one: 'async'})
-  mount(manf, ['bar'], {two: 'async'})
+  mount(manf, ['foo'], { one: 'async' })
+  mount(manf, ['bar'], { two: 'async' })
 
-  t.deepEqual(manf, {foo: {one: 'async'}, bar: {two: 'async'}})
+  t.deepEqual(manf, { foo: { one: 'async' }, bar: { two: 'async' } })
 
   unmount(manf, ['foo'])
 
-  t.deepEqual(manf, {bar: {two: 'async'}})
+  t.deepEqual(manf, { bar: { two: 'async' } })
 
   t.end()
-
 })
 
-
 tape('deep unmount', function (t) {
-  var manf = {}
+  const manf = {}
 
-  mount(manf, ['foo'], {one: 'async'})
-  mount(manf, ['foo', 'bar'], {two: 'async'})
+  mount(manf, ['foo'], { one: 'async' })
+  mount(manf, ['foo', 'bar'], { two: 'async' })
 
-  t.deepEqual(manf, {foo: {one: 'async', bar: {two: 'async'}}})
+  t.deepEqual(manf, { foo: { one: 'async', bar: { two: 'async' } } })
 
   unmount(manf, ['foo', 'bar'])
 
-  t.deepEqual(manf, {foo: {one: 'async'}})
+  t.deepEqual(manf, { foo: { one: 'async' } })
 
   t.end()
-
 })
 
 tape('deep unmount 2', function (t) {
+  const manf = {}
 
-  var manf = {}
+  m.mount(manf, ['foo', 'bar'], { two: 'async' })
 
-  m.mount(manf, ['foo', 'bar'], {two: 'async'})
-
-  t.deepEqual(manf, {foo: {bar: {two: 'async'}}})
+  t.deepEqual(manf, { foo: { bar: { two: 'async' } } })
 
   m.unmount(manf, ['foo', 'bar'])
 
   t.deepEqual(manf, {})
 
   t.end()
-
 })
-

--- a/test/permissions.js
+++ b/test/permissions.js
@@ -1,15 +1,12 @@
 
+const permissions = require('../permissions')
 
-
-var permissions = require('../permissions')
-
-var tape = require('tape')
+const tape = require('tape')
 
 tape('allowlist', function (t) {
+  const p = permissions()
 
-  var p = permissions()
-
-  p({allow: ['foo', 'bar', 'baz']})
+  p({ allow: ['foo', 'bar', 'baz'] })
 
   if (process.env.TEST_VERBOSE) console.log(p)
 
@@ -24,60 +21,49 @@ tape('allowlist', function (t) {
 })
 
 tape('nested allowlist', function (t) {
-  var p = permissions()
+  const p = permissions()
 
-  p({allow: ['foo']})
+  p({ allow: ['foo'] })
 
   t.ifError(p.test(['foo', 'quxx']))
   t.end()
-
 })
 
 tape('nested blocklist', function (t) {
+  const p = permissions()
 
-  var p = permissions()
-
-  p({deny: ['foo']})
+  p({ deny: ['foo'] })
 
   t.ok(p.test(['foo', 'quxx']))
   t.end()
-
 })
-
 
 tape('deep blocklist', function (t) {
+  const p = permissions()
 
-  var p = permissions()
-
-  p({deny: [['foo', 'quxx']]})
+  p({ deny: [['foo', 'quxx']] })
 
   t.ok(p.test(['foo', 'quxx']))
   t.notOk(p.test(['foo', 'bar']))
   t.end()
-
 })
 
-
 tape('deep blocklist, dotted strings', function (t) {
+  const p = permissions()
 
-  var p = permissions()
-
-  p({deny: ['foo.quxx']})
+  p({ deny: ['foo.quxx'] })
 
   t.ok(p.test(['foo', 'quxx']))
   t.notOk(p.test(['foo', 'bar']))
   t.end()
-
 })
 
 tape('matches', function (t) {
+  const p = permissions()
 
+  p({ allow: ['bar', 'foo'], deny: ['foo.quxx'] })
 
-  var p = permissions()
-
-  p({allow: ['bar', 'foo'], deny: ['foo.quxx']})
-
-  function allowed(path) {
+  function allowed (path) {
     t.notOk(p.test(path), 'allowed:' + path)
   }
 

--- a/test/psc.js
+++ b/test/psc.js
@@ -1,16 +1,14 @@
-var codec = require('packet-stream-codec')
+const codec = require('packet-stream-codec')
 // run tests with PSC
 
 require('./async')(codec, true)
 require('./abort')(codec, true)
 require('./closed')(codec, true)
-//require('./emit')(codec, true)
+// require('./emit')(codec, true)
 
-//this test isn't passing right,
-//but scuttlebot is passing its tests
-//and we ran this test with jsonb either );
-//so ... YOLO
+// this test isn't passing right,
+// but scuttlebot is passing its tests
+// and we ran this test with jsonb either );
+// so ... YOLO
 
-//require('./stream-end')(codec, true)
-
-
+// require('./stream-end')(codec, true)

--- a/test/pull-weird.js
+++ b/test/pull-weird.js
@@ -1,25 +1,22 @@
 
+const tape = require('tape')
 
-var tape = require('tape')
+const Weird = require('../pull-weird')
 
-var Weird = require('../pull-weird')
+const PacketStream = require('packet-stream')
 
-var PacketStream = require('packet-stream')
-
-var pull = require('pull-stream')
+const pull = require('pull-stream')
 
 tape('aborts pull-weird correctly', function (t) {
-
   t.plan(2)
-  var ps = PacketStream({})
-
+  const ps = PacketStream({})
 
   pull(
     function (abort, cb) {
-      if(abort) {
+      if (abort) {
         t.ok(true)
       } else {
-        cb('the stream must flow')
+        cb(new Error('the stream must flow'))
       }
     },
     Weird(ps),
@@ -27,10 +24,8 @@ tape('aborts pull-weird correctly', function (t) {
       read(true, function (err) {
         t.ok(err)
       })
-
     }
   )
 
   ps.destroy(true)
-
 })

--- a/test/scuttlebot.js
+++ b/test/scuttlebot.js
@@ -1,22 +1,21 @@
 
-var pull = require('pull-stream')
-var tape = require('tape')
-var Muxrpc = require('../')
+const pull = require('pull-stream')
+const tape = require('tape')
+const Muxrpc = require('../')
 
-var manifest = { hello: 'sync' }
-var api = {
+const manifest = { hello: 'sync' }
+const api = {
   hello: function (n) {
-    if(this._emit) this._emit('hello', n)
+    if (this._emit) this._emit('hello', n)
     if (process.env.TEST_VERBOSE) console.log('hello from ' + this.id)
     return n + ':' + this.id
   }
 }
 
 tape('give a muxrpc instance an id', function (t) {
-
-  var bob = Muxrpc(null, manifest)  (api)
-  var alice = Muxrpc(manifest, null)  ()
-  var as = alice.createStream()
+  const bob = Muxrpc(null, manifest)(api)
+  const alice = Muxrpc(manifest, null)()
+  const as = alice.createStream()
   pull(as, bob.createStream(), as)
 
   bob.id = 'Alice'
@@ -28,12 +27,10 @@ tape('give a muxrpc instance an id', function (t) {
   })
 })
 
-
 tape('initialize muxrpc with an id', function (t) {
-
-  var bob = Muxrpc(null, manifest)  (api, null, 'Alice')
-  var alice = Muxrpc(manifest, null)  ()
-  var as = alice.createStream()
+  const bob = Muxrpc(null, manifest)(api, null, 'Alice')
+  const alice = Muxrpc(manifest, null)()
+  const as = alice.createStream()
   pull(as, bob.createStream(), as)
 
   alice.hello('bob', function (err, data) {
@@ -43,14 +40,12 @@ tape('initialize muxrpc with an id', function (t) {
   })
 })
 
-
 tape('emit an event from the called api function', function (t) {
-
   t.plan(3)
 
-  var bob = Muxrpc(null, manifest)  (api)
-  var alice = Muxrpc(manifest, null)  ()
-  var as = alice.createStream()
+  const bob = Muxrpc(null, manifest)(api)
+  const alice = Muxrpc(manifest, null)()
+  const as = alice.createStream()
   pull(as, bob.createStream(), as)
 
   bob.id = 'Alice'

--- a/test/util.js
+++ b/test/util.js
@@ -1,17 +1,14 @@
+const u = require('../util')
 
-
-var u = require('../util')
-
-var tape = require('tape')
+const tape = require('tape')
 
 tape('set, get, prefix', function (t) {
-
-  var o = {}
+  const o = {}
   u.set(o, ['foo', 'bar', 'baz'], 24)
 
   t.equal(u.get(o, ['foo', 'bar', 'baz']), 24)
 
-  t.deepEqual(o, {foo: {bar: {baz: 24}}})
+  t.deepEqual(o, { foo: { bar: { baz: 24 } } })
 
   t.notOk(u.prefix(o, ['foo', 'baz']))
 
@@ -20,12 +17,9 @@ tape('set, get, prefix', function (t) {
   t.notOk(u.prefix(o, ['blah']))
 
   t.end()
-
 })
 
-
 tape('prefix 0', function (t) {
-
   t.ok(
     u.prefix({
       foo: true

--- a/util.js
+++ b/util.js
@@ -1,62 +1,63 @@
-'use strict';
-var pull = require('pull-stream')
+'use strict'
+const pull = require('pull-stream')
 
 function isString (s) {
-  return 'string' === typeof s
+  return typeof s === 'string'
 }
 
 function isEmpty (obj) {
-  for(var k in obj) return false;
-  return true
+  if (!obj) return true
+  return Object.keys(obj).length === 0
 }
 
-//I wrote set as part of permissions.js
-//and then later mount, they do nearly the same thing
-//but not quite. this should be refactored sometime.
-//what differs is that set updates the last key in the path
-//to the new value, but mount merges the last value
-//which makes sense if it's an object, and set makes sense if it's
-//a string/number/boolean.
+// I wrote set as part of permissions.js
+// and then later mount, they do nearly the same thing
+// but not quite. this should be refactored sometime.
+// what differs is that set updates the last key in the path
+// to the new value, but mount merges the last value
+// which makes sense if it's an object, and set makes sense if it's
+// a string/number/boolean.
 
 exports.set = function (obj, path, value) {
-  var _obj, _k
-  for(var i = 0; i < path.length; i++) {
-    var k = path[i]
+  let _obj, _k
+  for (let i = 0; i < path.length; i++) {
+    const k = path[i]
     obj[k] = obj[k] || {}
-    _obj = obj; _k = k
+    _obj = obj
+    _k = k
     obj = obj[k]
   }
   _obj[_k] = value
 }
 
 exports.get = function (obj, path) {
-  if(isString(path)) return obj[path]
-  var value
-  for(var i = 0; i < path.length; i++) {
-    var k = path[i]
+  if (isString(path)) return obj[path]
+  let value
+  for (let i = 0; i < path.length; i++) {
+    const k = path[i]
     value = obj = obj[k]
-    if(null == obj) return obj
+    if (obj == null) return obj
   }
   return value
 }
 
 exports.prefix = function (obj, path) {
-  var value
+  let value
 
-  for(var i = 0; i < path.length; i++) {
-    var k = path[i]
+  for (let i = 0; i < path.length; i++) {
+    const k = path[i]
     value = obj = obj[k]
-    if('object' !== typeof obj) {
+    if (typeof obj !== 'object') {
       return obj
     }
   }
-  return 'object' !== typeof value ? !!value : false
+  return typeof value !== 'object' ? !!value : false
 }
 
-function mkPath(obj, path) {
-  for(var i in path) {
-    var key = path[i]
-    if(!obj[key]) obj[key]={}
+function mkPath (obj, path) {
+  for (const i in path) {
+    const key = path[i]
+    if (!obj[key]) obj[key] = {}
     obj = obj[key]
   }
 
@@ -65,36 +66,51 @@ function mkPath(obj, path) {
 
 function rmPath (obj, path) {
   (function r (obj, i) {
-    var key = path[i]
-    if(!obj) return
-    else if(path.length - 1 === i)
+    const key = path[i]
+    if (!obj) return
+    else if (path.length - 1 === i) {
       delete obj[key]
-    else if(i < path.length) r(obj[key], i+1)
-    if(isEmpty(obj[key])) delete obj[key]
+    } else if (i < path.length) r(obj[key], i + 1)
+    if (isEmpty(obj[key])) delete obj[key]
   })(obj, 0)
 }
 
 function merge (obj, _obj) {
-  for(var k in _obj)
+  for (const k in _obj) {
     obj[k] = _obj[k]
+  }
   return obj
 }
 
 exports.mount = function (obj, path, _obj) {
-  if(!Array.isArray(path))
+  if (!Array.isArray(path)) {
     throw new Error('path must be array of strings')
+  }
   return merge(mkPath(obj, path), _obj)
 }
+
 exports.unmount = function (obj, path) {
   return rmPath(obj, path)
 }
 
-function isSource    (t) { return 'source' === t }
-function isSink      (t) { return 'sink'   === t }
-function isDuplex    (t) { return 'duplex' === t }
-function isSync      (t) { return 'sync'  === t }
-function isAsync     (t) { return 'async'  === t }
-function isRequest   (t) { return isSync(t) || isAsync(t) }
+function isSource (t) {
+  return t === 'source'
+}
+function isSink (t) {
+  return t === 'sink'
+}
+function isDuplex (t) {
+  return t === 'duplex'
+}
+function isSync (t) {
+  return t === 'sync'
+}
+function isAsync (t) {
+  return t === 'async'
+}
+function isRequest (t) {
+  return isSync(t) || isAsync(t)
+}
 
 function abortSink (err) {
   return function (read) {
@@ -103,33 +119,36 @@ function abortSink (err) {
 }
 
 function abortDuplex (err) {
-  return {source: pull.error(err), sink: abortSink(err)}
+  return { source: pull.error(err), sink: abortSink(err) }
 }
 
 exports.errorAsStream = function (type, err) {
-  return (
-      isSource(type)  ? pull.error(err)
-    : isSink(type)    ? abortSink(err)
-    :                   abortDuplex(err)
-  )
+  return isSource(type)
+    ? pull.error(err)
+    : isSink(type)
+      ? abortSink(err)
+      : abortDuplex(err)
 }
-
 
 exports.errorAsStreamOrCb = function (type, err, cb) {
   return (
-      isRequest(type) ? cb(err)
-    : isSource(type)  ? pull.error(err)
-    : isSink(type)    ? abortSink(err)
-    :                   cb(err), abortDuplex(err)
+    isRequest(type)
+      ? cb(err)
+      : isSource(type)
+        ? pull.error(err)
+        : isSink(type)
+          ? abortSink(err)
+          : cb(err),
+    abortDuplex(err)
   )
 }
 
 exports.pipeToStream = function (type, _stream, stream) {
-  if(isSource(type))
+  if (isSource(type)) {
     _stream(stream)
-  else if (isSink(type))
+  } else if (isSink(type)) {
     stream(_stream)
-  else if (isDuplex(type))
+  } else if (isDuplex(type)) {
     pull(_stream, stream, _stream)
+  }
 }
-


### PR DESCRIPTION
Similar to https://github.com/ssb-js/secret-stack/pull/53, this just introduces `standardx` which applies a conventional code style on all JS files, and warns against weird code, like multiple statements on the same line (muxrpc had lots of this). I didn't do much else than `npm run lint` and fix linting warnings, just to keep this PR simple to review. I have other code quality PRs coming up for this module.

I recommend taking a look at `package.json` changes first, and then changes to the `*.js` files.