### PR TITLE
lite renames and refactors using ES6

### DIFF
--- a/local-api.js
+++ b/local-api.js
@@ -10,9 +10,7 @@ module.exports = function createLocalCall (api, manifest, perms) {
   }
 
   function localCall (type, name, args) {
-    if (name === 'emit') {
-      throw new Error('emit has been removed')
-    }
+    if (name === 'emit') throw new Error('emit has been removed')
 
     // is there a way to know whether it's sync or async?
     if (type === 'async') {
@@ -29,13 +27,13 @@ module.exports = function createLocalCall (api, manifest, perms) {
     }
 
     if (!has(type, name)) {
-      throw new Error('no ' + type + ':' + name)
+      throw new Error(`no ${type}:${name}`)
     }
 
     return u.get(api, name).apply(this, args)
   }
 
-  return function (type, name, args) {
+  return function localCallWithPerms (type, name, args) {
     const err = perms.pre(name, args)
     if (err) throw err
     return localCall.call(this, type, name, args)


### PR DESCRIPTION
A bunch of light-weight refactors such as:

- Use arrow functions that are more concise
- Put names on anonymous functions so that they are more debuggable in stack traces
- Use `{ name, value }` instead of `{ name: name, value: value }`
- Use `if (cb) cb()` instead of `cb && cb()`
- Use string interpolation