### PR TITLE
add coverage script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+coverage/

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/ssbc/muxrpc.git"
   },
   "dependencies": {
+    "c8": "^7.11.0",
     "explain-error": "^1.0.1",
     "packet-stream": "~2.0.0",
     "packet-stream-codec": "^1.1.3",
@@ -30,6 +31,7 @@
     "prepublishOnly": "npm ls && npm test",
     "tape": "tape test/*.js | tap-bail | tap-spec",
     "test": "standardx '**/*.js' && npm run tape",
+    "coverage": "c8 --reporter=lcov npm run tape",
     "test-verbose": "TEST_VERBOSE=1 npm test",
     "lint": "standardx --fix '**/*.js'"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "git://github.com/ssbc/muxrpc.git"
   },
+  "files": [
+    "*.js"
+  ],
   "dependencies": {
     "c8": "^7.11.0",
     "explain-error": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "*.js"
   ],
   "dependencies": {
-    "c8": "^7.11.0",
     "explain-error": "^1.0.1",
     "packet-stream": "~2.0.0",
     "packet-stream-codec": "^1.1.3",
@@ -19,6 +18,7 @@
     "pull-stream": "^3.6.10"
   },
   "devDependencies": {
+    "c8": "^7.11.0",
     "cont": "~1.0.1",
     "json-buffer": "~2.0.9",
     "pull-abortable": "~4.1.0",


### PR DESCRIPTION
Basic house keeping PR.

Coverage looks like this:

![Screenshot from 2022-01-19 16-33-12](https://user-images.githubusercontent.com/90512/150151464-c53708b2-f28c-46d7-8b1e-78f70ef0b372.png)

And the package on npm will contain these files (after defining `files` array):

```
npm notice 
npm notice 📦  muxrpc@6.5.3
npm notice === Tarball Contents === 
npm notice 1.1kB LICENSE       
npm notice 41B   api.js        
npm notice 2.3kB index.js      
npm notice 1.0kB local-api.js  
npm notice 2.1kB permissions.js
npm notice 1.9kB pull-weird.js 
npm notice 1.9kB remote-api.js 
npm notice 3.8kB stream.js     
npm notice 3.2kB util.js       
npm notice 1.2kB package.json  
npm notice 7.4kB README.md     
npm notice === Tarball Details === 
npm notice name:          muxrpc                                  
npm notice version:       6.5.3                                   
npm notice filename:      muxrpc-6.5.3.tgz                        
npm notice package size:  9.2 kB                                  
npm notice unpacked size: 26.0 kB                                 
npm notice shasum:        d008a98fd86eb9488b5368f21fbf1f6299b3581d
npm notice integrity:     sha512-XZ6MvfsVymYCC[...]o2oTBzIBJKdYw==
npm notice total files:   11                                      
npm notice 
muxrpc-6.5.3.tgz
```