### PR TITLE
add debug feature for packet-stream-codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,10 @@
     "url": "git://github.com/ssbc/muxrpc.git"
   },
   "files": [
-    "*.js"
+    "*.js/"
   ],
   "dependencies": {
+    "debug": "^4.3.3",
     "explain-error": "^1.0.1",
     "packet-stream": "~2.0.0",
     "packet-stream-codec": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debug": "^4.3.3",
     "explain-error": "^1.0.1",
     "packet-stream": "~2.0.0",
-    "packet-stream-codec": "^1.1.3",
+    "packet-stream-codec": "^1.2.0",
     "pull-goodbye": "0.0.2",
     "pull-stream": "^3.6.10"
   },

--- a/stream.js
+++ b/stream.js
@@ -4,6 +4,7 @@ const pullWeird = require('./pull-weird')
 const goodbye = require('pull-goodbye')
 const u = require('./util')
 const explain = require('explain-error')
+const debug = require('debug')('muxrpc:psc')
 
 module.exports = function initStream (localCall, codec, onClose) {
   let ps = PacketStream({
@@ -95,7 +96,7 @@ module.exports = function initStream (localCall, codec, onClose) {
     // this error will be handled in PacketStream.close
   }))
 
-  ws = codec ? codec(ws) : ws
+  ws = codec ? codec(ws, debug.enabled ? debug.namespace : false) : ws
 
   ws.remoteCall = function (type, name, args, cb) {
     if (name === 'emit') return ps.message(args)


### PR DESCRIPTION
This PR adds a debugging feature, where you can run the application with `DEBUG=muxrpc:psc` or `DEBUG=muxrpc:*` or `DEBUG=*` and it will print all messages encoded and decoded via packet-stream-codec.