### PR TITLE
replace explain-error with clarify-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "dependencies": {
     "debug": "^4.3.3",
-    "explain-error": "^1.0.1",
+    "clarify-error": "^1.0.0",
     "packet-stream": "~2.0.0",
     "packet-stream-codec": "^1.2.0",
     "pull-goodbye": "0.0.3",

--- a/remote-api.js
+++ b/remote-api.js
@@ -1,5 +1,5 @@
 'use strict'
-const explain = require('explain-error')
+const clarify = require('clarify-error')
 const u = require('./util')
 
 /**
@@ -22,7 +22,7 @@ function recurse (obj, manifest, path, remoteCall) {
 }
 
 function noop (err) {
-  if (err) throw explain(err, 'callback not provided')
+  if (err) throw clarify(err, 'callback not provided')
 }
 
 function createRemoteApi (obj, manifest, actualRemoteCall, bootstrapCB) {

--- a/stream.js
+++ b/stream.js
@@ -3,7 +3,7 @@ const PacketStream = require('packet-stream')
 const pullWeird = require('./pull-weird')
 const goodbye = require('pull-goodbye')
 const u = require('./util')
-const explain = require('explain-error')
+const clarify = require('clarify-error')
 const debug = require('debug')('muxrpc:psc')
 
 module.exports = function initStream (localCall, codec, onClose) {
@@ -31,7 +31,7 @@ module.exports = function initStream (localCall, codec, onClose) {
         localCall('async', name, args)
       } catch (err) {
         if (inCB || called) {
-          throw explain(err, 'no callback provided to muxrpc async funtion')
+          throw clarify(err, 'no callback provided to muxrpc async funtion')
         }
         cb(err)
       }
@@ -142,7 +142,7 @@ module.exports = function initStream (localCall, codec, onClose) {
 
     ps.close((err) => {
       if (cb) cb(err)
-      else if (err) throw explain(err, 'no callback provided for muxrpc close')
+      else if (err) throw clarify(err, 'no callback provided for muxrpc close')
     })
 
     return this


### PR DESCRIPTION
## Context

1. I'd like to use explain-error more often because conceptually it's a neat idea that should A LOT help us when debugging
1. I had some free time so I wanted to do something small and fun

## Problem

explain-error is useful, but it's a bit buggy (when errors don't have a stack it produces a useless "stackless error" string) and it's quite outdated.

## Solution

I rewrote the library as [clarify-error](https://github.com/staltz/clarify-error) and it's mostly compatible with explain-error, with the differences:

- Written in TypeScript (means it probably handles all corner cases better)
- 100% test coverage
- Renders stackless errors in a nicer way, see below

**Before**

```js
throw explain('foo', 'bar')
```

```
Error: stackless error
    at module.exports (/home/staltz/oss/explain-error/index.js:18:19)
    at Object.<anonymous> (/home/staltz/oss/explain-error/example.js:10:7)
```

**After**

```js
throw clarify('foo', 'bar')
```

```
Error: bar
    at Object.<anonymous> (/home/staltz/oss/clarify-error/example.js:10:7)
  Error: foo
```